### PR TITLE
Recognise the 'apple' provider ID in attribute importer mapper

### DIFF
--- a/provider/resource_keycloak_attribute_importer_identity_provider_mapper.go
+++ b/provider/resource_keycloak_attribute_importer_identity_provider_mapper.go
@@ -67,7 +67,7 @@ func getAttributeImporterIdentityProviderMapperFromData(ctx context.Context, dat
 		}
 
 		rec.Config.Claim = data.Get("claim_name").(string)
-	} else if identityProvider.ProviderId == "facebook" || identityProvider.ProviderId == "google" {
+	} else if identityProvider.ProviderId == "apple" || identityProvider.ProviderId == "facebook" || identityProvider.ProviderId == "google" {
 		rec.IdentityProviderMapper = fmt.Sprintf("%s-user-attribute-mapper", identityProvider.ProviderId)
 		rec.Config.JsonField = data.Get("claim_name").(string)
 		rec.Config.UserAttributeName = data.Get("user_attribute").(string)


### PR DESCRIPTION
This allows the provider to be configure `keycloak_attribute_importer_identity_provider_mapper` resources with the [Apple Identity Provider for Keycloak plug-in](https://github.com/klausbetz/apple-identity-provider-keycloak).

Fortunately, all the actual differences are buried in the provider itself and the mapper just needs to do the same thing as for `facebook` and `google`.