### PR TITLE
Fix the smtp server password based authentication broken on realm update

### DIFF
--- a/docs/resources/realm.md
+++ b/docs/resources/realm.md
@@ -33,8 +33,10 @@ resource "keycloak_realm" "realm" {
     from = "example@example.com"
 
     auth {
+	  auth_type = "basic"
       username = "tom"
       password = "password"
+	
     }
   }
 
@@ -161,6 +163,7 @@ This block supports the following arguments:
 - `auth` - (Optional) Enables authentication to the SMTP server.  This block supports the following arguments:
     - `username` - (Required) The SMTP server username.
     - `password` - (Required) The SMTP server password.
+	- auth_type - (Optional) The authentication type. Only `basic` is supported by the provider which is for password based authentication.
 
 ### Internationalization
 

--- a/keycloak/realm.go
+++ b/keycloak/realm.go
@@ -170,6 +170,7 @@ type SmtpServer struct {
 	Ssl                types.KeycloakBoolQuoted `json:"ssl,omitempty"`
 	User               string                   `json:"user,omitempty"`
 	Password           string                   `json:"password,omitempty"`
+	AuthType           string                   `json:"authType,omitempty"`
 }
 
 func (keycloakClient *KeycloakClient) NewRealm(ctx context.Context, realm *Realm) error {

--- a/provider/resource_keycloak_realm.go
+++ b/provider/resource_keycloak_realm.go
@@ -303,6 +303,12 @@ func resourceKeycloakRealm() *schema.Resource {
 											return smtpServerPassword == "**********"
 										},
 									},
+									"auth_type": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Default:      "basic",
+										ValidateFunc: validation.StringInSlice([]string{"basic"}, false), // Only basic is supported by the provider for now
+									},
 								},
 							},
 						},
@@ -815,6 +821,8 @@ func getRealmFromData(data *schema.ResourceData, keycloakVersion *version.Versio
 			smtpServer.Auth = true
 			smtpServer.User = auth["username"].(string)
 			smtpServer.Password = auth["password"].(string)
+			smtpServer.AuthType = auth["auth_type"].(string)
+
 		} else {
 			smtpServer.Auth = false
 		}
@@ -1245,6 +1253,7 @@ func setRealmData(data *schema.ResourceData, realm *keycloak.Realm, keycloakVers
 
 			auth["username"] = realm.SmtpServer.User
 			auth["password"] = realm.SmtpServer.Password
+			auth["auth_type"] = realm.SmtpServer.AuthType
 
 			smtpSettings["auth"] = []interface{}{auth}
 		}


### PR DESCRIPTION
That branch is a partial fix for https://github.com/keycloak/terraform-provider-keycloak/issues/1194

When a realm  created by the provider with smtp server settings and password based authentication on the smtp server is updated via the console the smtp authentication is broken.

It happens on keycloak 26.2 which introduced token based authentication https://www.keycloak.org/docs/latest/release_notes/index.html#token-based-authentication-for-smtp-xoauth2

The commit just fixes that issue. It does not provide support for token based authentication.
